### PR TITLE
Update v4l2capture.zig

### DIFF
--- a/src/v4l2capture.zig
+++ b/src/v4l2capture.zig
@@ -7,7 +7,7 @@ const c = @cImport({
 });
 
 const Buffer = struct {
-    start: []align(std.heap.page_size_min) u8,
+    start: []align(std.heap.pageSize()) u8,
     length: usize,
 };
 


### PR DESCRIPTION
Update page size alignment to use runtime-determined value

From the previous:
  start: []align(std.mem.page_size) u8,
To the new on compilation value:
  start: []align(std.heap.pageSize()) u8,

References:
https://ziglang.org/download/0.14.0/release-notes.html#Runtime-Page-Size